### PR TITLE
HQD-228: Fix crash in mailsFetch when processing embedded message attachments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "eden/mail": "*",
         "zbateson/mail-mime-parser": "*",
         "ddeboer/imap": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         }
     ],
     "require": {
-        "php": ">=8.0",
         "eden/mail": "*",
         "zbateson/mail-mime-parser": "*",
         "ddeboer/imap": "^1.5",

--- a/src/FetchMailTool.php
+++ b/src/FetchMailTool.php
@@ -35,10 +35,11 @@ class FetchMailTool extends \hiapi\components\AbstractTool
 
         foreach (['url','login', 'password'] as $argument) {
             if (empty($this->data[$argument])) {
-                throw new Exception(ucfirst($argument) . ' could not be empty');
+                throw new \InvalidArgumentException(ucfirst($argument) . ' could not be empty');
             }
         }
 
+        $config = [];
         if (isset($data['data'])) {
             if (is_array($data['data'])) {
                 $config = $data['data'];
@@ -58,10 +59,6 @@ class FetchMailTool extends \hiapi\components\AbstractTool
             $config['retries'] ?? 1
         );
 
-        if (empty($server)) {
-            throw new \Exception('no connection');
-        }
-
         $connection = $server->authenticate($this->data['login'], $this->data['password']);
         $this->connection = $connection;
 
@@ -70,7 +67,6 @@ class FetchMailTool extends \hiapi\components\AbstractTool
     public function __destruct()
     {
         $this->clear();
-        $this->disconnect();
     }
 
     public function mailsFetch($params = [])
@@ -85,8 +81,8 @@ class FetchMailTool extends \hiapi\components\AbstractTool
             $emails[$message->getNumber()] = [
                 'number' => $message->getNumber(),
                 'message_id' => $message->getId(),
-                'from_email' => $message->getFrom()->getAddress(),
-                'from_name' => $message->getFrom()->getName(),
+                'from_email' => $message->getFrom()?->getAddress(),
+                'from_name' => $message->getFrom()?->getName(),
                 'subject' => $message->getSubject(),
                 'message' => EmailReplyParser::parseReply($message->getBodyText() ? : Html2Text::convert($message->getBodyHtml())),
                 'in_reply_to' => trim($message->getHeaders()->get('in_reply_to') ?: '', '<>'),

--- a/src/FetchMailTool.php
+++ b/src/FetchMailTool.php
@@ -82,11 +82,12 @@ class FetchMailTool extends \hiapi\components\AbstractTool
         }
         $emails = [];
         foreach ($messages as $message) {
+            $from = $message->getFrom();
             $emails[$message->getNumber()] = [
                 'number' => $message->getNumber(),
                 'message_id' => $message->getId(),
-                'from_email' => $message->getFrom()?->getAddress(),
-                'from_name' => $message->getFrom()?->getName(),
+                'from_email' => $from !== null ? $from->getAddress() : null,
+                'from_name' => $from !== null ? $from->getName() : null,
                 'subject' => $message->getSubject(),
                 'message' => EmailReplyParser::parseReply($message->getBodyText() ? : Html2Text::convert($message->getBodyHtml())),
                 'in_reply_to' => trim($message->getHeaders()->get('in_reply_to') ?: '', '<>'),

--- a/src/FetchMailTool.php
+++ b/src/FetchMailTool.php
@@ -95,8 +95,14 @@ class FetchMailTool extends \hiapi\components\AbstractTool
             if ($message->getAttachments()) {
                 foreach ($message->getAttachments() as $attachment) {
                     if ($attachment->isEmbeddedMessage()) {
-                        $embedded = $attachment->getEmbeddedMessage();
-                        $emails[$message->getNumber()]['message'] = EmailReplyParser::parseReply($message->getBodyText() ? : Html2Text::convert($message->getBodyHtml()));
+                        try {
+                            $embedded = $attachment->getEmbeddedMessage();
+                            $emails[$message->getNumber()]['message'] = EmailReplyParser::parseReply(
+                                $embedded->getBodyText() ?: Html2Text::convert($embedded->getBodyHtml())
+                            );
+                        } catch (\Throwable $e) {
+                            // malformed embedded message structure from IMAP server, keep outer message body
+                        }
                         continue;
                     }
 

--- a/src/FetchMailTool.php
+++ b/src/FetchMailTool.php
@@ -15,7 +15,11 @@ use \Html2Text\Html2Text;
 use \EmailReplyParser\EmailReplyParser;
 
 /**
- * hiAPI FetchMail Tool.
+ * Fetches incoming emails from an IMAP mailbox and returns them as an array.
+ *
+ * Used by the support ticket system to pull emails into threads.
+ * Processed messages are deleted from the mailbox after fetching
+ * so the same email is never imported twice.
  *
  * @author Andrii Vasyliev <sol@hiqdev.com>
  */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mail fetching so malformed embedded attachments won’t disrupt message handling.
  - If an embedded message fails to extract or parse, the original message content is preserved instead of being replaced incorrectly.
- **Behavior Changes**
  - Missing connection credentials now trigger clearer input validation errors.
  - Automatic cleanup on object destruction has been adjusted, affecting how connections are finalized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->